### PR TITLE
Helper funcs

### DIFF
--- a/wire/common.go
+++ b/wire/common.go
@@ -11,6 +11,7 @@ import (
 	"crypto/rand"
 	"encoding/binary"
 	"io"
+	"time"
 )
 
 // readElement reads the next sequence of bytes from r using big endian
@@ -37,6 +38,15 @@ func readElement(r io.Reader, element interface{}) error {
 			return err
 		}
 		*e = binary.BigEndian.Uint32(b)
+		return nil
+
+	case *ObjectType:
+		b := scratch[0:4]
+		_, err := io.ReadFull(r, b)
+		if err != nil {
+			return err
+		}
+		*e = ObjectType(binary.BigEndian.Uint32(b))
 		return nil
 
 	case *int64:
@@ -84,6 +94,16 @@ func readElement(r io.Reader, element interface{}) error {
 		if err != nil {
 			return err
 		}
+		return nil
+
+	// Message timestamp.
+	case *time.Time:
+		b := scratch[0:8]
+		_, err := io.ReadFull(r, b)
+		if err != nil {
+			return err
+		}
+		*e = time.Unix(int64(binary.BigEndian.Uint64(b)), 0)
 		return nil
 
 	// IP address.
@@ -176,6 +196,15 @@ func writeElement(w io.Writer, element interface{}) error {
 		}
 		return nil
 
+	case ObjectType:
+		b := scratch[0:4]
+		binary.BigEndian.PutUint32(b, uint32(e))
+		_, err := w.Write(b)
+		if err != nil {
+			return err
+		}
+		return nil
+
 	case int64:
 		b := scratch[0:8]
 		binary.BigEndian.PutUint64(b, uint64(e))
@@ -218,6 +247,16 @@ func writeElement(w io.Writer, element interface{}) error {
 	// Message header command.
 	case [CommandSize]uint8:
 		_, err := w.Write(e[:])
+		if err != nil {
+			return err
+		}
+		return nil
+
+	// Message timestamp.
+	case time.Time:
+		b := scratch[0:8]
+		binary.BigEndian.PutUint64(b, uint64(e.Unix()))
+		_, err := w.Write(b)
 		if err != nil {
 			return err
 		}

--- a/wire/common_test.go
+++ b/wire/common_test.go
@@ -13,6 +13,7 @@ import (
 	"io"
 	"reflect"
 	"testing"
+	"time"
 
 	"github.com/davecgh/go-spew/spew"
 	"github.com/monetas/bmutil/wire"
@@ -120,6 +121,14 @@ func TestElementWire(t *testing.T) {
 		{
 			wire.BitmessageNet(wire.MainNet),
 			[]byte{0xe9, 0xbe, 0xb4, 0xd9},
+		},
+		{
+			wire.ObjectTypePubKey,
+			[]byte{0x00, 0x00, 0x0, 0x01},
+		},
+		{
+			time.Unix(0x495fab29, 0), // 2009-01-03 12:15:05 -0600 CST)
+			[]byte{0x00, 0x00, 0x00, 0x00, 0x49, 0x5f, 0xab, 0x29},
 		},
 		// Type not supported by the "fast" path and requires reflection.
 		{

--- a/wire/msgobject_test.go
+++ b/wire/msgobject_test.go
@@ -1,10 +1,32 @@
 package wire_test
 
 import (
+	"bytes"
 	"testing"
+	"time"
 
 	"github.com/monetas/bmutil/wire"
 )
+
+var pubkey = []wire.PubKey{
+	wire.PubKey([wire.PubKeySize]byte{
+		23, 24, 25, 26, 27, 28, 29, 30, 31, 32, 33, 34, 35, 36, 37, 38,
+		39, 40, 41, 42, 43, 44, 45, 46, 47, 48, 49, 50, 51, 52, 53, 54,
+		55, 56, 57, 58, 59, 60, 61, 62, 63, 64, 65, 66, 67, 68, 69, 70,
+		71, 72, 73, 74, 75, 76, 77, 78, 79, 80, 81, 82, 83, 84, 85, 86}),
+	wire.PubKey([wire.PubKeySize]byte{
+		87, 88, 89, 90, 91, 92, 93, 94, 95, 96, 97, 98, 99, 100, 101, 102,
+		103, 104, 105, 106, 107, 108, 109, 110, 111, 112, 113, 114, 115, 116, 117, 118,
+		119, 120, 121, 122, 123, 124, 125, 126, 127, 128, 129, 130, 131, 132, 133, 134,
+		135, 136, 137, 138, 139, 140, 141, 142, 143, 144, 145, 146, 147, 148, 149, 150}),
+}
+
+var shahash = wire.ShaHash([wire.HashSize]byte{
+	98, 99, 100, 101, 102, 103, 104, 105, 106, 107, 108, 109, 110, 111, 112, 113,
+	114, 115, 116, 117, 118, 119, 120, 121, 122, 123, 124, 125, 126, 127, 128, 129})
+
+var ripehash = wire.RipeHash([wire.RipeHashSize]byte{
+	78, 79, 80, 81, 82, 83, 84, 85, 86, 87, 88, 89, 90, 91, 92, 93, 94, 95, 96, 97})
 
 func TestObjectTypeString(t *testing.T) {
 	// check if unknowns are handled properly
@@ -22,6 +44,134 @@ func TestObjectTypeString(t *testing.T) {
 		str = i.String()
 		if str == "Unknown" {
 			t.Errorf("did not expect Unknown for %d", i)
+		}
+	}
+}
+
+// TestEncodeAndDecodeObjectHeader tests EncodeObjectHeader and DecodeObjectHeader
+// It is not necessary to test separate cases for different object types.
+func TestEncodeAndDecodeObjectHeader(t *testing.T) {
+	tests := []struct {
+		nonce   uint64
+		expires time.Time
+		objType wire.ObjectType
+		version uint64
+		stream  uint64
+	}{
+		{
+			nonce:   uint64(123),
+			expires: time.Now(),
+			objType: wire.ObjectType(0),
+			version: 0,
+			stream:  1,
+		},
+		{
+			nonce:   uint64(8390),
+			expires: time.Now().Add(-37 * time.Hour),
+			objType: wire.ObjectType(66),
+			version: 33,
+			stream:  17,
+		},
+		{
+			nonce:   uint64(65),
+			expires: time.Now().Add(5 * time.Second),
+			objType: wire.ObjectType(2),
+			version: 2,
+			stream:  8,
+		},
+	}
+
+	for i, test := range tests {
+		buf := &bytes.Buffer{}
+		err := wire.EncodeMsgObjectHeader(buf, test.nonce, test.expires, test.objType, test.version, test.stream)
+		if err != nil {
+			t.Errorf("Error encoding header in test case %d.", i)
+		}
+		nonce, expires, objType, version, stream, err := wire.DecodeMsgObjectHeader(buf)
+		if err != nil {
+			t.Errorf("Error decoding header in test case %d.", i)
+		}
+		if nonce != test.nonce {
+			t.Errorf("Error on test case %d: nonce should be %x, got %x", i, test.nonce, nonce)
+		}
+		if expires.Unix() != test.expires.Unix() {
+			t.Errorf("Error on test case %d: expire time should be %x, got %x", i, test.expires.Unix(), expires.Unix())
+		}
+		if objType != test.objType {
+			t.Errorf("Error on test case %d: object type should be %d, got %d", i, test.objType, objType)
+		}
+		if version != test.version {
+			t.Errorf("Error on test case %d: version should be %d, got %d", i, test.version, version)
+		}
+		if stream != test.stream {
+			t.Errorf("Error on test case %d: stream should be %d, got %d", i, test.stream, stream)
+		}
+	}
+}
+
+// TestDecodeMsgObject tests DecodeMsgObject and checks if it returns an error if it should.
+func TestDecodeMsgObject(t *testing.T) {
+	expires := time.Now().Add(300 * time.Minute)
+
+	tests := []struct {
+		input       []byte // The input to the function.
+		errExpected bool   // Whether an error is expected.
+	}{
+		{ // Error case: nil input.
+			nil,
+			true,
+		},
+		{ // Error case. Incomplete header.
+			[]byte{},
+			true,
+		},
+		{ // Error case. Incomplete body.
+			[]byte{
+				0, 0, 0, 0, 0, 0, 0, 123, 0, 0, 0, 0, 85, 75, 111, 20,
+				0, 0, 0, 0, 4, 1, 98, 99, 100, 101, 102, 103, 104, 105, 106, 107,
+				108, 109, 110, 111, 112, 113, 114, 115, 116, 117, 118, 119, 120, 121, 122, 123,
+				124, 125, 126},
+			true,
+		},
+		{ // Valid case: GetPubKey object.
+			[]byte{
+				0, 0, 0, 0, 0, 0, 0, 123, 0, 0, 0, 0, 85, 75, 111, 20,
+				0, 0, 0, 0, 4, 1, 98, 99, 100, 101, 102, 103, 104, 105, 106, 107,
+				108, 109, 110, 111, 112, 113, 114, 115, 116, 117, 118, 119, 120, 121, 122, 123,
+				124, 125, 126, 127, 128, 129},
+			false,
+		},
+		{ // Valid case: PubKey object.
+			wire.EncodeMessage(wire.NewMsgPubKey(543, expires, 4, 1, 2, &pubkey[0], &pubkey[1], 3, 5,
+				[]byte{4, 5, 6, 7, 8, 9, 10}, &shahash, []byte{11, 12, 13, 14, 15, 16, 17, 18})),
+			false,
+		},
+		{ // Valid case: Msg object.
+			wire.EncodeMessage(wire.NewMsgMsg(765, expires, 1, 1,
+				[]byte{90, 87, 66, 45, 3, 2, 120, 101, 78, 78, 78, 7, 85, 55, 2, 23},
+				1, 1, 2, &pubkey[0], &pubkey[1], 3, 5, &ripehash, 1,
+				[]byte{21, 22, 23, 24, 25, 26, 27, 28},
+				[]byte{20, 21, 22, 23, 24, 25, 26, 27},
+				[]byte{19, 20, 21, 22, 23, 24, 25, 26})),
+			false,
+		},
+		{ // Valid case: Broadcast object.
+			wire.EncodeMessage(wire.NewMsgBroadcast(876, expires, 1, 1, &shahash,
+				[]byte{90, 87, 66, 45, 3, 2, 120, 101, 78, 78, 78, 7, 85, 55, 2, 23},
+				1, 1, 2, &pubkey[0], &pubkey[1], 3, 5, &ripehash, 1,
+				[]byte{27, 28, 29, 30, 31, 32, 33, 34, 35, 36, 37, 38, 39, 40, 41},
+				[]byte{42, 43, 44, 45, 46, 47, 48, 49, 50, 51, 52, 53, 54, 55, 56})),
+			false,
+		},
+		{ // Valid case: unknown object.
+			wire.EncodeMessage(wire.NewMsgUnknownObject(345, expires, wire.ObjectType(4), 1, 1, []byte{77, 82, 53, 48, 96, 1})),
+			false,
+		},
+	}
+
+	for i, test := range tests {
+		if _, err := wire.DecodeMsgObject(test.input); (err != nil) != test.errExpected {
+			t.Errorf("failed test case %d.", i)
 		}
 	}
 }

--- a/wire/pubkey_test.go
+++ b/wire/pubkey_test.go
@@ -232,7 +232,7 @@ func TestToBtcec(t *testing.T) {
 		bmPubKey, _ := wire.NewPubKey(test.pubKeyBytes[1:])
 		btcPubKeyExp, btcErrExp := btcec.ParsePubKey(test.pubKeyBytes, btcec.S256())
 		btcPubKeyTest, btcErrTest := bmPubKey.ToBtcec()
-		
+
 		if btcErrExp != nil {
 			if btcErrTest == nil {
 				t.Errorf("Error case %d: expecting error %s, but no error was returned. ", test_case, btcErrExp)

--- a/wire/shahash.go
+++ b/wire/shahash.go
@@ -56,6 +56,9 @@ func (hash *ShaHash) SetBytes(newHash []byte) error {
 
 // IsEqual returns true if target is the same as hash.
 func (hash *ShaHash) IsEqual(target *ShaHash) bool {
+	if target == nil {
+		return false
+	}
 	return bytes.Equal(hash[:], target[:])
 }
 

--- a/wire/shahash_test.go
+++ b/wire/shahash_test.go
@@ -53,6 +53,10 @@ func TestShaHash(t *testing.T) {
 			hash, shaHash)
 	}
 
+	if hash.IsEqual(nil) {
+		t.Errorf("IsEqual: should return false for nil input.")
+	}
+
 	// Set hash from byte slice and ensure contents match.
 	err = hash.SetBytes(shaHash.Bytes())
 	if err != nil {


### PR DESCRIPTION
* Added helper functions DecodeMsgObject, EncodeMessage, and MessageHash. 

* Added tests for EncodeObjectHeader and DecodeObjectHeader. 

* ObjectType and Time are now handled directly by readElement and writeElement. This makes things a litte cleaner and simpler. Tests included. 

* ShaHash.IsEqual checks for a nil input and returns false if so. Tests included. 