### PR TITLE
Add tests and increase coverage

### DIFF
--- a/address_test.go
+++ b/address_test.go
@@ -73,3 +73,59 @@ func TestDecodeAddress(t *testing.T) {
 		}
 	}
 }
+
+func TestAddressErrors(t *testing.T) {
+	// Address.Encode
+	addr := bmutil.Address{Version: 1, Stream: 1, Ripe: [20]byte{0, 21, 243,
+		247, 60, 104, 72, 169, 139, 195, 72, 196, 85, 228, 167, 173, 177, 1,
+		165, 242}}
+	str, err := addr.Encode()
+	if str != "" {
+		t.Error("EncodeAddress: address string due to error not empty")
+	}
+	if err != bmutil.ErrUnknownAddressType {
+		t.Errorf("EncodeAddress: unexpected error, expected UnknownAddressType"+
+			" got %v", err)
+	}
+
+	// Address.Decode
+	decodeAddressErrorAddresses := []string{
+		// data too short
+		"BM-554ddssdf",
+		// checksum mismatch
+		"BM-2DBXxtaBSV37DsHjN978mRiMbX5rdKNvJ2",
+		// invalid v3 address, ripe length < 18
+		"BM-4biUVd9M1g46fES4Ggz8ktmnfoJndYA",
+		// invalid v3 address, ripe length > 20
+		"BM-QYkxMN39XYE4WtRxHMGNPxLbcv4nWGSRtVdH",
+		// invalid v4 address, null bytes in front
+		"BM-2cShcu4VoVChUUc9GQnFrJtRe9NdmEoBUq",
+		// invalid v4 address, ripe length < 4
+		"BM-3xSpfkKJqnFf",
+		// invalid v4 address, ripe length > 20
+		"BM-YPRfqu7T4fXxxhEfAWCdpebVYRm7mkwr3M4u",
+		// invalid address version
+		"BM-9tSxgK6q4X6bNdEbyMRgGBcfnFC3MoW3Bp5",
+	}
+
+	for i, addr := range decodeAddressErrorAddresses {
+		_, err := bmutil.DecodeAddress(addr)
+		if err == nil {
+			t.Errorf("DecodeAddress: for test #%d expected error got none", i)
+		}
+	}
+}
+
+// Test Tag, PrivateKey and PrivateKeySingleHash
+func TestCalcHash(t *testing.T) {
+	for _, pair := range addressTests {
+		addr, err := bmutil.DecodeAddress(pair.addrString)
+		if err != nil {
+			t.Errorf("while decoding %s, got error %v", pair.addrString, err)
+		}
+		// TODO
+		addr.PrivateKeySingleHash()
+		addr.PrivateKey()
+		addr.Tag()
+	}
+}

--- a/identity/private.go
+++ b/identity/private.go
@@ -153,13 +153,20 @@ func ImportWIF(address, signingKeyWif, encryptionKeyWif string,
 		return nil, err
 	}
 
-	return &Private{
+	priv := &Private{
 		Address:            *addr,
 		SigningKey:         privSigningKey,
 		EncryptionKey:      privEncryptionKey,
 		NonceTrialsPerByte: nonceTrials,
 		ExtraBytes:         extraBytes,
-	}, nil
+	}
+
+	// check if everything is valid
+	priv.CreateAddress(addr.Version, addr.Stream) // CreateAddress generates ripe
+	if !bytes.Equal(priv.Address.Ripe[:], addr.Ripe[:]) {
+		return nil, errors.New("address does not correspond to private keys")
+	}
+	return priv, nil
 }
 
 // ExportWIF exports a Private identity to WIF for storage on disk or use by

--- a/identity/private_test.go
+++ b/identity/private_test.go
@@ -124,3 +124,54 @@ func TestNewDeterministic(t *testing.T) {
 		}
 	}
 }
+
+func TestErrors(t *testing.T) {
+	// NewDeterministic
+	_, err := identity.NewDeterministic("abcabc", 0) // 0 initial zeros
+	if err == nil {
+		t.Error("NewDeterministic: 0 initial zeros, got no error")
+	}
+
+	// ImportWIF
+
+	// invalid address
+	_, err = identity.ImportWIF("BM-9tSxgK6q4X6bNdEbyMRgGBcfnFC3MoW3Bp5", "",
+		"", 1000, 1000)
+	if err == nil {
+		t.Error("ImportWIF: invalid address, got no error")
+	}
+
+	// invalid signing key
+	_, err = identity.ImportWIF("BM-2cWgt4u3shyzQ8vP56uzMSe2iajy8r4Hxe",
+		"sd5f48erdfoiopadsfa5d6sf405", "", 1000, 1000)
+	if err == nil {
+		t.Error("ImportWIF: invalid signing key, got no error")
+	}
+
+	// invalid encryption key
+	_, err = identity.ImportWIF("BM-2cV9RshwouuVKWLBoyH5cghj3kMfw5G7BJ",
+		"5KHBtHsy9eWz6fFZzJCNMVVJ3r4m7AbuzYRE3hwkKZ2H7BEZrGU",
+		"sd5f48erdfoiopadsfa5d6sf405", 1000, 1000)
+	if err == nil {
+		t.Error("ImportWIF: invalid encryption key, got no error")
+	}
+
+	// address does not match
+	_, err = identity.ImportWIF("BM-2DB6AzjZvzM8NkS3HMYWMP9R1Rt778mhN8",
+		"5JXVjG9CNFh17kCawPxCtekJBei9gv6hzmawBGFkuciTCMaxeJD",
+		"5KQC3fHBCUNyBoXeEpgphrqa314Cvy4beS21Zg1rvrj1FY3Tgqb", 1000, 1000)
+	if err == nil {
+		t.Error("ImportWIF: address mismatch, got no error")
+	}
+
+	// ExportWIF
+	id, err := identity.ImportWIF("BM-2cU2a336vzu7SEuPPa1UTWgrVg8mWiqzpm",
+		"5Ke7eXNJmQYpdeVckePnRWEu5TwPrE9BsZfZZQGGb1jzor9fXit",
+		"5HwY8h5skGnaFaQZZv9UzMJdJbdtuZBjXhsSyDK9msGernqPRDt", 1000, 1000)
+
+	id.Address.Version = 5 // set invalid version
+	_, _, _, err = id.ExportWIF()
+	if err == nil {
+		t.Error("ExportWIF: invalid address, got no error")
+	}
+}

--- a/identity/public.go
+++ b/identity/public.go
@@ -48,9 +48,6 @@ func (id *Public) hash() []byte {
 // IdentityFromPubKeyMsg generates an *identity.Public object based on a
 // wire.MsgPubKey object.
 func IdentityFromPubKeyMsg(msg *wire.MsgPubKey) (*Public, error) {
-	if msg == nil {
-		return nil, errors.New("MsgPubKey is null")
-	}
 	switch msg.Version {
 	case wire.SimplePubKeyVersion, wire.ExtendedPubKeyVersion:
 		signingKey, err := msg.SigningKey.ToBtcec()

--- a/identity/public_test.go
+++ b/identity/public_test.go
@@ -3,3 +3,131 @@
 // license that can be found in the LICENSE file.
 
 package identity_test
+
+import (
+	"bytes"
+	"testing"
+	"time"
+
+	"github.com/monetas/bmutil/identity"
+	"github.com/monetas/bmutil/pow"
+	"github.com/monetas/bmutil/wire"
+)
+
+func TestIdentityFromPubKeyMsg(t *testing.T) {
+	id, err := identity.NewRandom(1)
+	if err != nil {
+		t.Fatal("identity generation failed")
+	}
+	enc := id.ToPublic().EncryptionKey.SerializeUncompressed()[1:]
+	sig := id.ToPublic().SigningKey.SerializeUncompressed()[1:]
+	var encryptKey wire.PubKey
+	var signingKey wire.PubKey
+	copy(encryptKey[:], enc)
+	copy(signingKey[:], sig)
+
+	// test version 2 message
+	id.CreateAddress(2, 1)
+	addr, err := id.Address.Encode()
+	if err != nil {
+		t.Fatalf("for error got %v", err)
+	}
+
+	validIdMsg := wire.NewMsgPubKey(123123, time.Now().Add(time.Hour), 2, 1, 1,
+		&signingKey, &encryptKey, 0, 0, nil, nil, nil)
+	testId, err := identity.IdentityFromPubKeyMsg(validIdMsg)
+	if err != nil {
+		t.Errorf("for error got %v", err)
+	}
+
+	if testAddr, _ := testId.Address.Encode(); testAddr != addr {
+		t.Errorf("generated address doesn't match, got %s expected %s",
+			testAddr, addr)
+	}
+	if testEnc := testId.EncryptionKey.SerializeUncompressed()[1:]; !bytes.Equal(
+		testEnc, enc) {
+		t.Errorf("public encryption key doesn't match, got %v expected %v",
+			testEnc, enc)
+	}
+	if testSig := testId.SigningKey.SerializeUncompressed()[1:]; !bytes.Equal(
+		testSig, sig) {
+		t.Errorf("public signing key doesn't match, got %v expected %v",
+			testSig, enc)
+	}
+	if testId.NonceTrialsPerByte != pow.DefaultNonceTrialsPerByte {
+		t.Errorf("nonce trials per byte doesn't match, got %d expected %d",
+			testId.NonceTrialsPerByte, pow.DefaultNonceTrialsPerByte)
+	}
+	if testId.ExtraBytes != pow.DefaultExtraBytes {
+		t.Errorf("extra bytes doesn't match, got %d expected %d",
+			testId.ExtraBytes, pow.DefaultExtraBytes)
+	}
+
+	// test version 3 message
+	id.CreateAddress(3, 1)
+	addr, err = id.Address.Encode()
+	if err != nil {
+		t.Fatalf("for error got %v", err)
+	}
+
+	validIdMsg = wire.NewMsgPubKey(123123, time.Now().Add(time.Hour), 3, 1, 1,
+		&signingKey, &encryptKey, 2000, 1500, nil, nil, nil)
+	testId, err = identity.IdentityFromPubKeyMsg(validIdMsg)
+	if err != nil {
+		t.Errorf("for error got %v", err)
+	}
+
+	if testAddr, _ := testId.Address.Encode(); testAddr != addr {
+		t.Errorf("generated address doesn't match, got %s expected %s",
+			testAddr, addr)
+	}
+	if testEnc := testId.EncryptionKey.SerializeUncompressed()[1:]; !bytes.Equal(
+		testEnc, enc) {
+		t.Errorf("public encryption key doesn't match, got %v expected %v",
+			testEnc, enc)
+	}
+	if testSig := testId.SigningKey.SerializeUncompressed()[1:]; !bytes.Equal(
+		testSig, sig) {
+		t.Errorf("public signing key doesn't match, got %v expected %v",
+			testSig, enc)
+	}
+	if testId.NonceTrialsPerByte != validIdMsg.NonceTrials {
+		t.Errorf("nonce trials per byte doesn't match, got %d expected %d",
+			testId.NonceTrialsPerByte, pow.DefaultNonceTrialsPerByte)
+	}
+	if testId.ExtraBytes != validIdMsg.ExtraBytes {
+		t.Errorf("extra bytes doesn't match, got %d expected %d",
+			testId.ExtraBytes, pow.DefaultExtraBytes)
+	}
+
+	// version 4 message should fail since it's encrypted
+	invMsg := wire.NewMsgPubKey(123123, time.Now().Add(time.Hour), 4, 1, 1,
+		&signingKey, &encryptKey, 2000, 1500, nil, nil, nil)
+	testId, err = identity.IdentityFromPubKeyMsg(invMsg)
+	if err == nil {
+		t.Errorf("got none expected error", err)
+	}
+
+	// invalid signing key
+	invKey := bytes.Repeat([]byte{0x00}, wire.PubKeySize)
+	var invSigningKey wire.PubKey
+	copy(invSigningKey[:], invKey)
+
+	invMsg = wire.NewMsgPubKey(123123, time.Now().Add(time.Hour), 3, 1, 1,
+		&invSigningKey, &encryptKey, 2000, 1500, nil, nil, nil)
+	testId, err = identity.IdentityFromPubKeyMsg(invMsg)
+	if err == nil {
+		t.Errorf("got no error", err)
+	}
+
+	// invalid encryption key
+	var invEncryptKey wire.PubKey
+	copy(invEncryptKey[:], invKey)
+
+	invMsg = wire.NewMsgPubKey(123123, time.Now().Add(time.Hour), 3, 1, 1,
+		&signingKey, &invEncryptKey, 2000, 1500, nil, nil, nil)
+	testId, err = identity.IdentityFromPubKeyMsg(invMsg)
+	if err == nil {
+		t.Errorf("got no error", err)
+	}
+}


### PR DESCRIPTION
Added tests for address and identity to bring up test coverage. Untested paths are those that have impossible/impractical errors.