### PR TITLE
ObjectMsg

### DIFF
--- a/helpers.go
+++ b/helpers.go
@@ -21,10 +21,3 @@ func Sha512(b []byte) []byte {
 func DoubleSha512(b []byte) []byte {
 	return Sha512(Sha512(b))
 }
-
-// CalcInventoryHash takes double sha512 of the bytes and returns the first
-// half. It is meant to be a helper function for quickly calculating inventory
-// hashes as required by the protocol.
-func CalcInventoryHash(b []byte) []byte {
-	return DoubleSha512(b)[:32]
-}

--- a/identity/private.go
+++ b/identity/private.go
@@ -75,8 +75,8 @@ func NewRandom(initialZeros int) (*Private, error) {
 	return id, nil
 }
 
-// Create identities based on a deterministic passphrase. Note that this does
-// not create an address.
+// NewDeterministic creates identities based on a deterministic passphrase.
+// Note that this does not create an address.
 func NewDeterministic(passphrase string, initialZeros uint64) (*Private, error) {
 	if initialZeros < 1 { // Cannot take this
 		return nil, errors.New("minimum 1 initial zero needed")

--- a/pow/pow_test.go
+++ b/pow/pow_test.go
@@ -11,6 +11,7 @@ import (
 	"time"
 
 	"github.com/monetas/bmutil/pow"
+	"github.com/monetas/bmutil/wire"
 )
 
 const (
@@ -112,13 +113,14 @@ func TestCheck(t *testing.T) {
 	refTime := time.Unix(1432295555, 0) // 22 May 2015, 5:22 PM IST
 	for n, tc := range tests {
 		b, _ := hex.DecodeString(tc.payload)
-		if !pow.Check(b, nonceTrials, extraBytes, refTime) {
+		msg, _ := wire.DecodeMsgObject(b)
+		if !pow.Check(msg, nonceTrials, extraBytes, refTime) {
 			t.Errorf("for test #%d check returned false", n)
 		}
 
-		// change a byte of nonce
-		b[0] = 0x12
-		if pow.Check(b, nonceTrials, extraBytes, refTime) {
+		// change nonce
+		msg.Nonce = 0x00
+		if pow.Check(msg, nonceTrials, extraBytes, refTime) {
 			t.Errorf("for test #%d check returned true", n)
 		}
 	}
@@ -126,7 +128,8 @@ func TestCheck(t *testing.T) {
 	refTime = time.Unix(1434714755, 0) // +28 days
 	for n, tc := range tests {
 		b, _ := hex.DecodeString(tc.payload)
-		if pow.Check(b, nonceTrials, extraBytes, refTime) {
+		msg, _ := wire.DecodeMsgObject(b)
+		if pow.Check(msg, nonceTrials, extraBytes, refTime) {
 			t.Errorf("for test #%d check returned true", n)
 		}
 	}

--- a/wire/invvect.go
+++ b/wire/invvect.go
@@ -27,7 +27,7 @@ type InvVect struct {
 	Hash ShaHash // Hash of the data
 }
 
-// NewInvVect returns a new InvVect using the provided type and hash.
+// NewInvVect returns a new InvVect using the provided hash.
 func NewInvVect(hash *ShaHash) *InvVect {
 	return &InvVect{
 		Hash: *hash,

--- a/wire/message.go
+++ b/wire/message.go
@@ -354,14 +354,7 @@ func ReadMessage(r io.Reader, bmnet BitmessageNet) (Message, []byte, error) {
 // the standard bitmessage header that goes along with every message sent over
 // the p2p connection.
 func EncodeMessage(msg Message) []byte {
-	buf := &bytes.Buffer{}
-	msg.Encode(buf)
+	var buf bytes.Buffer
+	msg.Encode(&buf)
 	return buf.Bytes()
-}
-
-// MessageHash takes a message and returns its hash (double sha512, as per the
-// bitmessage protocol) as it would be indexed in the database.
-func MessageHash(msg Message) *ShaHash {
-	hash, _ := NewShaHash(bmutil.CalcInventoryHash(EncodeMessage(msg)))
-	return hash
 }

--- a/wire/message_test.go
+++ b/wire/message_test.go
@@ -551,14 +551,14 @@ func TestEncodeMessageAndMessageHash(t *testing.T) {
 
 	for i, test := range tests {
 		encoded := wire.EncodeMessage(test.msg)
-		hash := wire.MessageHash(test.msg)
+		obj, _ := wire.ToMsgObject(test.msg)
 
 		if !bytes.Equal(test.expectedData, encoded) {
 			t.Errorf("On test case %d, expected %v, got %v: ", i, spew.Sdump(test.expectedData), spew.Sdump(encoded))
 		}
 
-		if !test.expectedHash.IsEqual(hash) {
-			t.Errorf("On test case %d, expected %v, got %v: ", i, spew.Sdump(test.expectedHash), spew.Sdump(hash))
+		if !test.expectedHash.IsEqual(obj.InventoryHash()) {
+			t.Errorf("On test case %d, expected %v, got %v: ", i, spew.Sdump(test.expectedHash), spew.Sdump(obj.InventoryHash()))
 		}
 	}
 }

--- a/wire/msgbroadcast.go
+++ b/wire/msgbroadcast.go
@@ -104,6 +104,12 @@ func (msg *MsgBroadcast) String() string {
 	return fmt.Sprintf("broadcast: v%d %d %s %d %x %x", msg.Version, msg.Nonce, msg.ExpiresTime, msg.StreamNumber, msg.Tag, msg.Encrypted)
 }
 
+// ToMsgObject converts the message into MsgObject.
+func (msg *MsgBroadcast) ToMsgObject() *MsgObject {
+	obj, _ := ToMsgObject(msg)
+	return obj
+}
+
 // NewMsgBroadcast returns a new object message that conforms to the
 // Message interface using the passed parameters and defaults for the remaining
 // fields.

--- a/wire/msggetpubkey.go
+++ b/wire/msggetpubkey.go
@@ -105,6 +105,12 @@ func (msg *MsgGetPubKey) String() string {
 	return fmt.Sprintf("getpubkey: v%d %d %s %d %x %x", msg.Version, msg.Nonce, msg.ExpiresTime, msg.StreamNumber, msg.Ripe, msg.Tag)
 }
 
+// ToMsgObject converts the message into MsgObject.
+func (msg *MsgGetPubKey) ToMsgObject() *MsgObject {
+	obj, _ := ToMsgObject(msg)
+	return obj
+}
+
 // NewMsgGetPubKey returns a new object message that conforms to the
 // Message interface using the passed parameters and defaults for the remaining
 // fields.

--- a/wire/msgmsg.go
+++ b/wire/msgmsg.go
@@ -85,6 +85,12 @@ func (msg *MsgMsg) String() string {
 	return fmt.Sprintf("msg: v%d %d %s %d %x", msg.Version, msg.Nonce, msg.ExpiresTime, msg.StreamNumber, msg.Encrypted)
 }
 
+// ToMsgObject converts the message into MsgObject.
+func (msg *MsgMsg) ToMsgObject() *MsgObject {
+	obj, _ := ToMsgObject(msg)
+	return obj
+}
+
 // NewMsgMsg returns a new object message that conforms to the Message interface
 // using the passed parameters and defaults for the remaining fields.
 func NewMsgMsg(nonce uint64, expires time.Time, version, streamNumber uint64, encrypted []byte, addressVersion, fromStreamNumber uint64, behavior uint32, signingKey, encryptKey *PubKey, nonceTrials, extraBytes uint64, destination *RipeHash, encoding uint64, message, ack, signature []byte) *MsgMsg {

--- a/wire/msgobject.go
+++ b/wire/msgobject.go
@@ -6,7 +6,9 @@ package wire
 
 import (
 	"bytes"
+	"fmt"
 	"io"
+	"io/ioutil"
 	"time"
 
 	"github.com/monetas/bmutil"
@@ -92,13 +94,118 @@ func DecodeMsgObjectHeader(r io.Reader) (nonce uint64, expiresTime time.Time,
 	return
 }
 
+// MsgObject implements the Message interface and represents a generic object.
+type MsgObject struct {
+	Nonce        uint64
+	ExpiresTime  time.Time
+	ObjectType   ObjectType
+	Version      uint64
+	StreamNumber uint64
+	Payload      []byte
+	invHash      *ShaHash
+}
+
+// Decode decodes r using the bitmessage protocol encoding into the receiver.
+// This is part of the Message interface implementation.
+func (msg *MsgObject) Decode(r io.Reader) error {
+	var err error
+	msg.Nonce, msg.ExpiresTime, msg.ObjectType, msg.Version,
+		msg.StreamNumber, err = DecodeMsgObjectHeader(r)
+	if err != nil {
+		return err
+	}
+
+	msg.Payload, err = ioutil.ReadAll(r)
+
+	return err
+}
+
+// Encode encodes the receiver to w using the bitmessage protocol encoding.
+// This is part of the Message interface implementation.
+func (msg *MsgObject) Encode(w io.Writer) error {
+	err := EncodeMsgObjectHeader(w, msg.Nonce, msg.ExpiresTime, msg.ObjectType,
+		msg.Version, msg.StreamNumber)
+	if err != nil {
+		return err
+	}
+
+	_, err = w.Write(msg.Payload)
+	return err
+}
+
+// Command returns the protocol command string for the message. This is part
+// of the Message interface implementation.
+func (msg *MsgObject) Command() string {
+	return CmdObject
+}
+
+// MaxPayloadLength returns the maximum length the payload can be for the
+// receiver. This is part of the Message interface implementation.
+func (msg *MsgObject) MaxPayloadLength() int {
+	return MaxPayloadOfMsgObject
+}
+
+func (msg *MsgObject) String() string {
+	return fmt.Sprintf("object: %s v%d, expires: %s, nonce: %d, stream: %d",
+		msg.ObjectType, msg.Version, msg.ExpiresTime, msg.Nonce, msg.StreamNumber)
+}
+
+// InventoryHash takes double sha512 of the bytes and returns the first half.
+// It calculates inventory hash of the object as required by the protocol.
+func (msg *MsgObject) InventoryHash() *ShaHash {
+	if msg.invHash == nil {
+		hash, _ := NewShaHash(bmutil.DoubleSha512(EncodeMessage(msg))[:32])
+		msg.invHash = hash
+	}
+	return msg.invHash
+}
+
+// Copy creates a new MsgObject identical to the original after a deep copy.
+func (msg *MsgObject) Copy() *MsgObject {
+	newMsg := *msg
+
+	newMsg.Payload = make([]byte, len(msg.Payload))
+	copy(newMsg.Payload, msg.Payload)
+
+	newMsg.invHash = nil // can be recalculated
+
+	return &newMsg
+}
+
 // DecodeMsgObject takes a byte array and turns it into an object message.
-func DecodeMsgObject(obj []byte) (Message, error) {
+func DecodeMsgObject(obj []byte) (*MsgObject, error) {
+	// Make sure that object type specific checks happen first.
 	msg, err := detectMessageType(obj, CmdObject)
 	if err != nil {
 		return nil, err
 	}
-
 	err = msg.Decode(bytes.NewReader(obj))
-	return msg, err
+	if err != nil {
+		return nil, err
+	}
+
+	// Object is good, so make it MsgObject.
+	msgObj := &MsgObject{}
+	msgObj.Decode(bytes.NewReader(obj)) // no error
+	return msgObj, err
+}
+
+// ToMsgObject converts a Message to the MsgObject concrete type.
+func ToMsgObject(msg Message) (*MsgObject, error) {
+	objMsg := &MsgObject{}
+	err := objMsg.Decode(bytes.NewReader(EncodeMessage(msg)))
+	return objMsg, err
+}
+
+// NewMsgObject returns a new object message that conforms to the Message
+// interface using the passed parameters and defaults for the remaining fields.
+func NewMsgObject(nonce uint64, expires time.Time, objectType ObjectType, version, streamNumber uint64, payload []byte) *MsgObject {
+	return &MsgObject{
+		Nonce:        nonce,
+		ExpiresTime:  expires,
+		ObjectType:   objectType,
+		Version:      version,
+		StreamNumber: streamNumber,
+		Payload:      payload,
+	}
 }

--- a/wire/msgobject.go
+++ b/wire/msgobject.go
@@ -6,6 +6,7 @@ package wire
 
 import (
 	"bytes"
+	"errors"
 	"fmt"
 	"io"
 	"io/ioutil"
@@ -192,9 +193,15 @@ func DecodeMsgObject(obj []byte) (*MsgObject, error) {
 
 // ToMsgObject converts a Message to the MsgObject concrete type.
 func ToMsgObject(msg Message) (*MsgObject, error) {
-	objMsg := &MsgObject{}
-	err := objMsg.Decode(bytes.NewReader(EncodeMessage(msg)))
-	return objMsg, err
+	switch msg.(type) {
+	case *MsgObject, *MsgGetPubKey, *MsgPubKey, *MsgMsg, *MsgBroadcast, *MsgUnknownObject:
+		objMsg := &MsgObject{}
+		err := objMsg.Decode(bytes.NewReader(EncodeMessage(msg)))
+		return objMsg, err
+
+	default:
+		return nil, errors.New("Invalid message type")
+	}
 }
 
 // NewMsgObject returns a new object message that conforms to the Message

--- a/wire/msgpubkey.go
+++ b/wire/msgpubkey.go
@@ -168,6 +168,12 @@ func (msg *MsgPubKey) String() string {
 	return fmt.Sprintf("pubkey: v%d %d %s %d %x", msg.Version, msg.Nonce, msg.ExpiresTime, msg.StreamNumber, msg.Tag)
 }
 
+// ToMsgObject converts the message into MsgObject.
+func (msg *MsgPubKey) ToMsgObject() *MsgObject {
+	obj, _ := ToMsgObject(msg)
+	return obj
+}
+
 // NewMsgPubKey returns a new object message that conforms to the Message
 // interface using the passed parameters and defaults for the remaining fields.
 func NewMsgPubKey(nonce uint64, expires time.Time,

--- a/wire/msgunknownobject.go
+++ b/wire/msgunknownobject.go
@@ -71,6 +71,12 @@ func (msg *MsgUnknownObject) String() string {
 	return fmt.Sprintf("unknown object: v%d %d %s %d %x", msg.Version, msg.Nonce, msg.ExpiresTime, msg.StreamNumber, msg.Payload)
 }
 
+// ToMsgObject converts the message into MsgObject.
+func (msg *MsgUnknownObject) ToMsgObject() *MsgObject {
+	obj, _ := ToMsgObject(msg)
+	return obj
+}
+
 // NewMsgUnknownObject returns a new object message that conforms to the
 // Message interface using the passed parameters and defaults for the remaining
 // fields.


### PR DESCRIPTION
Changed everything pertaining to objects to be of type wire.MsgObject. The aim is to simplify object handling.