### PR TITLE
Add deterministic key generation for multiple keys

### DIFF
--- a/identity/public.go
+++ b/identity/public.go
@@ -31,11 +31,6 @@ func (id *Public) CreateAddress(version, stream uint64) {
 	copy(id.Address.Ripe[:], id.hash())
 }
 
-func (id *Public) setDefaultPOWParams() {
-	id.NonceTrialsPerByte = pow.DefaultNonceTrialsPerByte
-	id.ExtraBytes = pow.DefaultExtraBytes
-}
-
 // hash returns the ripemd160 hash used in the address
 func (id *Public) hash() []byte {
 	return hashHelper(id.SigningKey.SerializeUncompressed(),


### PR DESCRIPTION
Fixed identity.NewDeterministic to return n number of keys as needed. Useful for deterministically generating Bitmessage identities based on a passphrase.